### PR TITLE
Add support NullResource

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -138,6 +138,10 @@ class Fractal implements JsonSerializable
      */
     protected function determineDataType($data)
     {
+        if (is_null($data)) {
+            return 'NullResource';
+        }
+        
         if (is_array($data)) {
             return 'collection';
         }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -64,7 +64,7 @@ class Fractal implements JsonSerializable
         $instance = new static(new Manager());
 
         $instance->data = $data ?: null;
-        $instance->dataType = $data ? $instance->determineDataType($data) : null;
+        $instance->dataType = $instance->determineDataType($data);
         $instance->transformer = $transformer ?: null;
         $instance->serializer = $serializer ?: null;
 

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -141,7 +141,7 @@ class Fractal implements JsonSerializable
         if (is_null($data)) {
             return 'NullResource';
         }
-        
+
         if (is_array($data)) {
             return 'collection';
         }

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -3,7 +3,9 @@
 namespace Spatie\Fractalistic\Test;
 
 use League\Fractal\Pagination\Cursor;
+use League\Fractal\Serializer\JsonApiSerializer;
 use Spatie\Fractalistic\ArraySerializer;
+use Spatie\Fractalistic\Fractal;
 
 class FractalTest extends TestCase
 {
@@ -110,6 +112,41 @@ class FractalTest extends TestCase
     {
         $resource = $this->fractal
             ->collection($this->testBooks, new TestTransformer())
+            ->createData();
+
+        $this->assertInstanceOf(\League\Fractal\Scope::class, $resource);
+    }
+
+    /** @test */
+    public function it_can_perform_a_null_item()
+    {
+        $array = Fractal::create(null, NullableTransformer::class)
+            ->serializeWith(new JsonApiSerializer())
+            ->withResourceName('books')
+            ->toArray();
+
+        $expectedArray = ['data' => null];
+
+        $this->assertEquals($expectedArray, $array);
+    }
+
+    /** @test */
+    public function it_can_create_a_null_resource()
+    {
+        $resource = Fractal::create(null, NullableTransformer::class)
+            ->serializeWith(new JsonApiSerializer())
+            ->withResourceName('books')
+            ->getResource();
+
+        $this->assertInstanceOf(\League\Fractal\Resource\ResourceInterface::class, $resource);
+    }
+
+    /** @test */
+    public function it_can_create_nul_fractal_data()
+    {
+        $resource = Fractal::create(null, NullableTransformer::class)
+            ->serializeWith(new JsonApiSerializer())
+            ->withResourceName('books')
             ->createData();
 
         $this->assertInstanceOf(\League\Fractal\Scope::class, $resource);

--- a/tests/NullableTransformer.php
+++ b/tests/NullableTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Fractalistic\Test;
+
+class NullableTransformer extends TestTransformer
+{
+    /**
+     * @param array $book
+     *
+     * @return array
+     */
+    public function transform(array $book = null)
+    {
+        return is_null($book) ? [] : parent::transform($book);
+    }
+}


### PR DESCRIPTION
Support `NULL` resource serialize

```php
/** @var $user User|null */
$user = getCurrentUser();
fractal($user, UserTransformer::class)
    ->serializeWith(new JsonApiSerializer())
    ->withResourceName('users')
    ->toArray();
```
And result:
```json
{
  "data": null
}
```
or 
```php
{
  "data": {
    "id": "1",
    "type": "users",
    "attributes": {}
  }
}
```