### PR TITLE
Handle empty arrays passed to collections

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -63,7 +63,7 @@ class Fractal implements JsonSerializable
     {
         $instance = new static(new Manager());
 
-        $instance->data = $data ?: null;
+        $instance->data = $data;
         $instance->dataType = $instance->determineDataType($data);
         $instance->transformer = $transformer ?: null;
         $instance->serializer = $serializer ?: null;

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -168,4 +168,15 @@ class FractalTest extends TestCase
             $this->createMock('League\Fractal\Pagination\PaginatorInterface')
         ));
     }
+
+    /** @test */
+    public function it_can_perform_an_empty_array()
+    {
+        $array = Fractal::create([], TestTransformer::class)
+            ->toArray();
+
+        $expectedArray = ['data' => []];
+
+        $this->assertEquals($expectedArray, $array);
+    }
 }


### PR DESCRIPTION
I was running into issues in my Laravel project using [laravel-fractal](https://github.com/spatie/laravel-fractal) with this code:

```php
$items = [];
$fractal = fractal($items, $transformer, new ArraySerializer);
```

I traced it back to this line in fractalistic:

```php
// src/Fractal.php

    public static function create($data = null, $transformer = null, $serializer = null)
    {
        $instance = new static(new Manager());

        $instance->data = $data ?: null;    // <--- HERE
        $instance->dataType = $instance->determineDataType($data);
        $instance->transformer = $transformer ?: null;
        $instance->serializer = $serializer ?: null;

        return $instance;
    }
```

If for whatever reason you end up passing an empty array as data, the ternary operator treats it as false, and `$instance->data` is set to `null`.  Then `$instance->dataType` is set `"collection"` (since an array is passed to it).  Eventually, this throws an exception:

```
Invalid argument supplied for foreach() /home/admin/domains/www.wareable.local/vendor/league/fractal/src/Scope.php
line 317
```

because it is trying to `foreach` over null (i.e. not an array).

This PR (plus accompanying test) fixes it but not trying to do any transformation on the data that gets passed to `Fractal::create()`.