### PR TITLE
Add ability to define collection & item after resource name

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -88,7 +88,9 @@ class Fractal implements JsonSerializable
      */
     public function collection($data, $transformer = null, $resourceName = null)
     {
-        $this->resourceName = $resourceName;
+        if (! is_null($resourceName)) {
+            $this->resourceName = $resourceName;
+        }
 
         return $this->data('collection', $data, $transformer);
     }
@@ -104,7 +106,9 @@ class Fractal implements JsonSerializable
      */
     public function item($data, $transformer = null, $resourceName = null)
     {
-        $this->resourceName = $resourceName;
+        if (! is_null($resourceName)) {
+            $this->resourceName = $resourceName;
+        }
 
         return $this->data('item', $data, $transformer);
     }

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -179,4 +179,26 @@ class FractalTest extends TestCase
 
         $this->assertEquals($expectedArray, $array);
     }
+
+    /** @test */
+    public function it_can_define_collection_after_resource_name()
+    {
+        $resource = Fractal::create()
+            ->withResourceName('tests')
+            ->collection($this->testBooks)
+            ->transformWith(new TestTransformer);
+
+        $this->assertEquals('tests', $resource->getResource()->getResourceKey());
+    }
+
+    /** @test */
+    public function it_can_define_item_after_resource_name()
+    {
+        $resource = Fractal::create()
+            ->withResourceName('tests')
+            ->item($this->testBooks[0])
+            ->transformWith(new TestTransformer);
+
+        $this->assertEquals('tests', $resource->getResource()->getResourceKey());
+    }
 }


### PR DESCRIPTION
I've faced a situation where I'm creating fractal response in constructor and filling resources in methods:

```php
public function __construct(Request $request)
{
    $this->response = fractal()
        ->withResourceName('users')
        ->transformWith(new UserTransformer)
        ->parseIncludes($request->input('include'));
}

public function index()
{
    // Some logic

    return $this->response->collection($users)->respond();
}

public function show($id)
{
    // Some logic

    return $this->response->item($user)->respond();
}
```

Without this change `collection` & `item` methods overwriting `resourceName` variable with `null` value and the only way to make it work - use `data('collection', $users)` method instead.