### PR TITLE
Allow classnames for Transformer and Serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,16 @@ Fractal::create()
    ->toArray();
 ```
 
-To make your code a bit shorter you could also pass the transform closure or class as a 
+You can also pass the classname of the Transformer:
+
+```php
+Fractal::create()
+   ->collection($books)
+   ->transformWith(BookTransformer::class)
+   ->toArray();
+```
+
+To make your code a bit shorter you could also pass the transform closure, class, or classname as a 
 second parameter of the `collection`-method:
 
 ```php
@@ -143,6 +152,17 @@ Fractal::create()
 
 //returns [['id' => 1], ['id' => 2]]
 ```
+
+You can also pass the serializer classname instead of an instantiation:
+
+```php
+Fractal::create()
+   ->collection($books)
+   ->transformWith(BookTransformer::class)
+   ->serializeWith(MySerializer::class)
+   ->toArray();
+```
+
 
 ### Changing the default serializer
 
@@ -300,6 +320,8 @@ Here are some examples
 Fractal::create($books, new BookTransformer())->toArray();
 
 Fractal::create($books, new BookTransformer(), new ArraySerializer())->toArray();
+
+Fractal::create($books, BookTransformer::class, ArraySerializer::class)->toArray();
 
 Fractal::create(['item1', 'item2'], function ($item) {
    return $item . '-transformed';

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -7,7 +7,6 @@ use JsonSerializable;
 use League\Fractal\Manager;
 use League\Fractal\Pagination\CursorInterface;
 use League\Fractal\Pagination\PaginatorInterface;
-use League\Fractal\Serializer\SerializerAbstract;
 use Spatie\Fractalistic\Exceptions\InvalidTransformation;
 use Spatie\Fractalistic\Exceptions\NoTransformerSpecified;
 
@@ -19,7 +18,7 @@ class Fractal implements JsonSerializable
     /** @var int */
     protected $recursionLimit = 10;
 
-    /** @var \League\Fractal\Serializer\SerializerAbstract */
+    /** @var string|\League\Fractal\Serializer\SerializerAbstract */
     protected $serializer;
 
     /** @var string|callable|\League\Fractal\TransformerAbstract */
@@ -55,7 +54,7 @@ class Fractal implements JsonSerializable
     /**
      * @param null|mixed $data
      * @param null|string|callable|\League\Fractal\TransformerAbstract $transformer
-     * @param null|\League\Fractal\Serializer\SerializerAbstract $serializer
+     * @param null|string|\League\Fractal\Serializer\SerializerAbstract $serializer
      *
      * @return \Spatie\Fractalistic\Fractal
      */
@@ -174,11 +173,11 @@ class Fractal implements JsonSerializable
     /**
      * Set the serializer to be used.
      *
-     * @param \League\Fractal\Serializer\SerializerAbstract $serializer
+     * @param string|\League\Fractal\Serializer\SerializerAbstract $serializer
      *
      * @return $this
      */
-    public function serializeWith(SerializerAbstract $serializer)
+    public function serializeWith($serializer)
     {
         $this->serializer = $serializer;
 
@@ -233,6 +232,7 @@ class Fractal implements JsonSerializable
      * Specify the excludes.
      *
      * @param array|string $excludes Array or string of resources to exclude.
+     *
      * @return $this
      */
     public function parseExcludes($excludes)
@@ -362,8 +362,9 @@ class Fractal implements JsonSerializable
         if (is_null($this->transformer)) {
             throw new NoTransformerSpecified();
         }
-        if (is_string($this->transformer)) {
-            $this->transformer = new $this->transformer;
+
+        if (is_string($this->serializer)) {
+            $this->serializer = new $this->serializer;
         }
 
         if (! is_null($this->serializer)) {
@@ -402,6 +403,10 @@ class Fractal implements JsonSerializable
             throw new InvalidTransformation();
         }
 
+        if (is_string($this->transformer)) {
+            $this->transformer = new $this->transformer;
+        }
+
         $resource = new $resourceClass($this->data, $this->transformer, $this->resourceName);
 
         $resource->setMeta($this->meta);
@@ -429,7 +434,7 @@ class Fractal implements JsonSerializable
      * Support for magic methods to included data.
      *
      * @param string $name
-     * @param array  $arguments
+     * @param array $arguments
      *
      * @return $this
      */
@@ -453,8 +458,9 @@ class Fractal implements JsonSerializable
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|array  $needles
+     * @param  string $haystack
+     * @param  string|array $needles
+     *
      * @return bool
      */
     protected function startsWith($haystack, $needles)

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -22,7 +22,7 @@ class Fractal implements JsonSerializable
     /** @var \League\Fractal\Serializer\SerializerAbstract */
     protected $serializer;
 
-    /** @var \League\Fractal\TransformerAbstract|callable */
+    /** @var string|callable|\League\Fractal\TransformerAbstract */
     protected $transformer;
 
     /** @var \League\Fractal\Pagination\PaginatorInterface */
@@ -54,7 +54,7 @@ class Fractal implements JsonSerializable
 
     /**
      * @param null|mixed $data
-     * @param null|callable|\League\Fractal\TransformerAbstract $transformer
+     * @param null|string|callable|\League\Fractal\TransformerAbstract $transformer
      * @param null|\League\Fractal\Serializer\SerializerAbstract $serializer
      *
      * @return \Spatie\Fractalistic\Fractal
@@ -80,9 +80,9 @@ class Fractal implements JsonSerializable
     /**
      * Set the collection data that must be transformed.
      *
-     * @param mixed                                             $data
-     * @param \League\Fractal\TransformerAbstract|callable|null $transformer
-     * @param string|null                                       $resourceName
+     * @param mixed $data
+     * @param null|string|callable|\League\Fractal\TransformerAbstract $transformer
+     * @param null|string $resourceName
      *
      * @return $this
      */
@@ -98,9 +98,9 @@ class Fractal implements JsonSerializable
     /**
      * Set the item data that must be transformed.
      *
-     * @param mixed                                             $data
-     * @param \League\Fractal\TransformerAbstract|callable|null $transformer
-     * @param string|null                                       $resourceName
+     * @param mixed $data
+     * @param null|string|callable|\League\Fractal\TransformerAbstract $transformer
+     * @param null|string $resourceName
      *
      * @return $this
      */
@@ -116,9 +116,9 @@ class Fractal implements JsonSerializable
     /**
      * Set the data that must be transformed.
      *
-     * @param string                                            $dataType
-     * @param mixed                                             $data
-     * @param \League\Fractal\TransformerAbstract|callable|null $transformer
+     * @param string $dataType
+     * @param mixed $data
+     * @param null|string|callable|\League\Fractal\TransformerAbstract $transformer
      *
      * @return $this
      */
@@ -160,16 +160,12 @@ class Fractal implements JsonSerializable
     /**
      * Set the class or function that will perform the transform.
      *
-     * @param \League\Fractal\TransformerAbstract|callable $transformer
+     * @param string|callable|\League\Fractal\TransformerAbstract $transformer
      *
      * @return $this
      */
     public function transformWith($transformer)
     {
-        if (is_string($transformer) && class_exists($transformer)) {
-            $transformer = new $transformer;
-        }
-
         $this->transformer = $transformer;
 
         return $this;
@@ -365,6 +361,9 @@ class Fractal implements JsonSerializable
     {
         if (is_null($this->transformer)) {
             throw new NoTransformerSpecified();
+        }
+        if (is_string($this->transformer)) {
+            $this->transformer = new $this->transformer;
         }
 
         if (! is_null($this->serializer)) {

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -53,6 +53,18 @@ class FractalTest extends TestCase
     }
 
     /** @test */
+    public function it_can_transform_a_collection_using_a_class_name()
+    {
+        $json = $this->fractal
+            ->collection($this->testBooks, TestTransformer::class)
+            ->toJson();
+
+        $expectedJson = '{"data":[{"id":1,"author":"Philip K Dick"},{"id":2,"author":"George R. R. Satan"}]}';
+
+        $this->assertEquals($expectedJson, $json);
+    }
+
+    /** @test */
     public function it_provides_a_method_to_specify_the_transformer()
     {
         $array = $this->fractal

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -34,4 +34,17 @@ class SerializerTest extends TestCase
 
         $this->assertEquals($expectedArray, $array);
     }
+
+    /** @test */
+    public function it_accepts_a_class_name_for_the_serializer()
+    {
+        $array = $this->fractal
+            ->item($this->testBooks[0], new TestTransformer())
+            ->serializeWith(ArraySerializer::class)
+            ->toArray();
+
+        $expectedArray = ['id' => 1, 'author' => 'Philip K Dick'];
+
+        $this->assertEquals($expectedArray, $array);
+    }
 }


### PR DESCRIPTION
This allows passing a classname (i.e. string) anywhere you can specify a Transformer or Serializer.

e.g., this will now work:

```php
Fractal::create($books, BookTransformer::class, ArraySerializer::class)->toArray();
```

(If this is accepted, I'll make a PR to [spatie/laravel-fractal](https://github.com/spatie/laravel-fractal) to support the changes there as well.)