### PR TITLE
toJson options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "league/fractal": "^0.16.0"
+        "league/fractal": "^0.17.0"
     },
     "require-dev": {
         "illuminate/pagination": "~5.3.0|~5.4.0",

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -336,11 +336,13 @@ class Fractal implements JsonSerializable
     /**
      * Perform the transformation to json.
      *
+     * @param int $options
+     *
      * @return string
      */
-    public function toJson()
+    public function toJson($options = 0)
     {
-        return $this->createData()->toJson();
+        return $this->createData()->toJson($options);
     }
 
     /**

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -18,8 +18,29 @@ class FractalTest extends TestCase
 
         $expectedJson = '{"data":[{"id":1,"author":"Philip K Dick"},{"id":2,"author":"George R. R. Satan"}]}';
 
+        $json = $this->fractal
+            ->collection($this->testBooks, new TestTransformer())
+            ->toJson(JSON_PRETTY_PRINT);
+
+        $expectedJson = <<<'JSON'
+{
+    "data": [
+        {
+            "id": 1,
+            "author": "Philip K Dick"
+        },
+        {
+            "id": 2,
+            "author": "George R. R. Satan"
+        }
+    ]
+}
+JSON;
+
         $this->assertEquals($expectedJson, $json);
     }
+
+
 
     /** @test */
     public function it_can_transform_multiple_items_using_a_transformer_to_an_array()

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -40,8 +40,6 @@ JSON;
         $this->assertEquals($expectedJson, $json);
     }
 
-
-
     /** @test */
     public function it_can_transform_multiple_items_using_a_transformer_to_an_array()
     {


### PR DESCRIPTION
This [great PR](https://github.com/thephpleague/fractal/pull/365) made it possible to use php's bitmask flags on json_encode.

I've been waiting long for that PR to be included in a release. Now 0.17 was released just an hour ago, so it should be possible to use this function in fractalistic too!

Note: this PR also updates the dependency to 0.17.

PS.: maybe it would be a good idea to use `~0.17` instead of `^0.17.0` so the newest fractal released could be used independently from fractalistic releases