### PR TITLE
Add public function to return resourceName

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -442,6 +442,17 @@ class Fractal implements JsonSerializable
         return $resource;
     }
 
+    
+    /**
+     * Return the resourceName.
+     *
+     * @return  string
+     */
+    public function getResourceName()
+    {
+        return $this->resourceName;
+    }
+    
     /**
      * Convert the object into something JSON serializable.
      */


### PR DESCRIPTION
There's no way to get the `resourceName` value, from the Transformer object! It will be useful if you want to use that from the DataArray or Array Serializers as it's used by the JsonApi Serializer.

I'm passing the fractal instance to my parent transformer, which has a function that returns the resource name as follow:
```php
    public function getResourceKey()
    {
        return $this->getFractalInstance()->getResourceName();
    }
```
