### PR TITLE
fix: Php 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "league/fractal": "^0.20.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "league/fractal": "^0.19.0"
+        "league/fractal": "^0.20.0"
     },
     "require-dev": {
         "illuminate/pagination": "~5.3.0|~5.4.0",

--- a/src/ArraySerializer.php
+++ b/src/ArraySerializer.php
@@ -14,7 +14,7 @@ class ArraySerializer extends BaseArraySerializer
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection(string $resourceKey, array $data): array
     {
         return $data;
     }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -455,7 +455,7 @@ class Fractal implements JsonSerializable
     /**
      * Convert the object into something JSON serializable.
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/tests/TestTransformer.php
+++ b/tests/TestTransformer.php
@@ -11,7 +11,7 @@ class TestTransformer extends TransformerAbstract
      *
      * @var array
      */
-    protected $availableIncludes = [
+    protected array $availableIncludes = [
         'characters',
         'publisher',
     ];

--- a/tests/TestTransformerWithIncludes.php
+++ b/tests/TestTransformerWithIncludes.php
@@ -11,7 +11,7 @@ class TestTransformerWithIncludes extends TransformerAbstract
      *
      * @var array
      */
-    protected $defaultIncludes = [
+    protected array $defaultIncludes = [
         'characters',
         'publisher',
         'title',

--- a/tests/TraversableClass.php
+++ b/tests/TraversableClass.php
@@ -4,6 +4,7 @@ namespace Spatie\Fractalistic\Test;
 
 use ArrayIterator;
 use IteratorAggregate;
+use Traversable;
 
 class TraversableClass implements IteratorAggregate
 {
@@ -18,7 +19,7 @@ class TraversableClass implements IteratorAggregate
     /**
      * @return array
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }


### PR DESCRIPTION
Addressed php 8.1 warnings by updating return types of inherited interfaces, and updating `league/fractal`.