### PR TITLE
Fix: make jsonSerialize backward compatibile with PHP 7.4

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -454,8 +454,11 @@ class Fractal implements JsonSerializable
 
     /**
      * Convert the object into something JSON serializable.
+     *
+     * @return array
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -250,4 +250,19 @@ JSON;
 
         $this->assertEquals('tests', $resource->getResource()->getResourceKey());
     }
+
+    /** @test */
+    public function it_can_convert_into_something_that_is_json_serializable()
+    {
+        $jsonSerialized = $this->fractal
+            ->collection($this->testBooks, new TestTransformer())
+            ->jsonSerialize();
+
+        $expectedArray = ['data' => [
+            ['id' => 1, 'author' => 'Philip K Dick'],
+            ['id' => 2, 'author' => 'George R. R. Satan'],
+        ]];
+
+        $this->assertEquals($expectedArray, $jsonSerialized);
+    }
 }


### PR DESCRIPTION
Issue
- `Fractal::jsonSerialize()` return type was changed to `mixed` by commit https://github.com/spatie/fractalistic/commit/4d3b8a68b6575e9b0202e842977c9c29224fd9ac#diff-9ebff18d48644c7d6e2c1006245d57ef9028099e796f76f967c8656aedadcf4bR458

  https://github.com/spatie/fractalistic/blob/5a89b24d3153a9c4b17cd1ed523b0a5ef9143558/src/Fractal.php#L458

-  `mixed` pseudo type is not compatible with PHP 7.4
- a type error is triggered

  ```
  TypeError
  Return value of Spatie\Fractalistic\Fractal::jsonSerialize() must be an instance of Spatie\Fractalistic\mixed, array returned 
  ```

Solution
- make return type compatible with PHP 7.4
- add attribute `#[\ReturnTypeWillChange]` to prevent warnings in PHP 8.1

Tests
- run successfully with PHP 7.4 and 8.1


Notes
- This fixes issue #54 