### PR TITLE
Change minimum requirement to PHP 8 and add type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "league/fractal": "^0.20.1"
     },
     "require-dev": {

--- a/src/ArraySerializer.php
+++ b/src/ArraySerializer.php
@@ -9,8 +9,8 @@ class ArraySerializer extends BaseArraySerializer
     /**
      * Serialize a collection to a plain array.
      *
-     * @param string $resourceKey
-     * @param array  $data
+     * @param string|null $resourceKey
+     * @param array $data
      *
      * @return array
      */

--- a/tests/SparseFieldsetsTest.php
+++ b/tests/SparseFieldsetsTest.php
@@ -12,7 +12,7 @@ it('can filter out fields', function () {
         'key3' => 'value3',
         ], function ($item) {
           return $item;
-      }, new ArraySerializer())
+      }, 'test_name')
       ->withResourceName('test')
       ->parseFieldsets(['test' => 'key1,key3'])
       ->toArray();


### PR DESCRIPTION
## This PR contains:
- [x] PHP 8 required as minimum PHP version
- [x] Updated code to have type hints for properties, method arguments, return types.
- [x] Initialized properties with null value where necessary
- [x] Updated `SparseFieldsetsTest` to correctly follow the method signature of `Fractal::item()` in test (identified after adding type hints)
- [ ] Remove docblocks