### PR TITLE
Test nested includes

### DIFF
--- a/tests/IncludesTest.php
+++ b/tests/IncludesTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\Fractalistic\Fractal;
+use Spatie\Fractalistic\Test\TestClasses\PublisherTransformer;
 use Spatie\Fractalistic\Test\TestClasses\TestTransformer;
 use function PHPUnit\Framework\assertEquals;
 
@@ -86,3 +87,66 @@ it('knows to ignore invalid includes param', function () {
         ->toArray();
     assertEquals($expectedArray, $array);
 });
+
+it('can parse nested includes', function ($includes): void {
+    $fractal = Fractal::create(getTestPublishers(), new PublisherTransformer())
+        ->parseIncludes($includes);
+
+    $result = $fractal->toArray();
+
+    $expectedArray = [
+        'data' => [
+            [
+                'name' => 'Elephant books',
+                'address' => 'Amazon rainforests, near the river',
+                'books' => [
+                    'data' => [
+                        [
+                            'id' => 1,
+                            'title' => 'Hogfather',
+                            'author' => [
+                                'data' => [
+                                    'name' => 'Philip K Dick',
+                                    'email' => 'philip@example.org',
+                                ],
+                            ],
+                        ]
+                    ],
+                ],
+            ],
+            [
+                'name' => 'Bloody Fantasy inc.',
+                'address' => 'Diagon Alley, before the bank, to the left',
+                'books' => [
+                    'data' => [
+                        [
+                            'id' => 2,
+                            'title' => 'Game Of Kill Everyone',
+                            'author' => [
+                                'data' => [
+                                    'name' => 'George R. R. Satan',
+                                    'email' => 'george@example.org',
+                                ],
+                            ],
+                        ]
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    expect($result)->toBe($expectedArray);
+})->with([
+    [
+        'string' => 'books,books.author',
+    ],
+    [
+        'array' => ['books', 'books.author'],
+    ],
+    [
+        'string: auto-loads parent' => 'books.author',
+    ],
+    [
+        'array: auto-loads parent' => ['books.author'],
+    ],
+]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,7 +9,6 @@
 use Spatie\Fractalistic\Fractal;
 use Spatie\Fractalistic\Test\TestClasses\Author;
 use Spatie\Fractalistic\Test\TestClasses\Book;
-use Spatie\Fractalistic\Test\TestClasses\Character;
 use Spatie\Fractalistic\Test\TestClasses\Publisher;
 
 uses()
@@ -57,11 +56,6 @@ function getTestPublishers(): array
     $authorA = new Author('Philip K Dick', 'philip@example.org');
     $authorB = new Author('George R. R. Satan', 'george@example.org');
 
-    $charA = new Character('Death');
-    $charB = new Character('Hex');
-    $charC = new Character('Ned Stark');
-    $charD = new Character('Tywin Lannister');
-
     $bookA = new Book(
         '1',
         'Hogfather',
@@ -84,19 +78,11 @@ function getTestPublishers(): array
 
     $bookA->author = $authorA;
     $bookA->publisher = $publisherA;
-    $bookA->characters = [$charA, $charB];
-    $authorA->characters = [$charA, $charB];
-    $charA->book = $bookA;
-    $charB->book = $bookA;
     $publisherA->books = [$bookA];
     $authorA->books = [$bookA];
 
     $bookB->author = $authorB;
     $bookB->publisher = $publisherB;
-    $bookB->characters = [$charC, $charD];
-    $authorB->characters = [$charC, $charD];
-    $charC->book = $bookB;
-    $charD->book = $bookB;
     $publisherB->books = [$bookB];
     $authorB->books = [$bookB];
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,6 +7,10 @@
 */
 
 use Spatie\Fractalistic\Fractal;
+use Spatie\Fractalistic\Test\TestClasses\Author;
+use Spatie\Fractalistic\Test\TestClasses\Book;
+use Spatie\Fractalistic\Test\TestClasses\Character;
+use Spatie\Fractalistic\Test\TestClasses\Publisher;
 
 uses()
     ->beforeEach(function () {
@@ -48,3 +52,53 @@ uses()
 | Functions
 |--------------------------------------------------------------------------
 */
+function getTestPublishers(): array
+{
+    $authorA = new Author('Philip K Dick', 'philip@example.org');
+    $authorB = new Author('George R. R. Satan', 'george@example.org');
+
+    $charA = new Character('Death');
+    $charB = new Character('Hex');
+    $charC = new Character('Ned Stark');
+    $charD = new Character('Tywin Lannister');
+
+    $bookA = new Book(
+        '1',
+        'Hogfather',
+        '1998',
+    );
+    $bookB = new Book(
+        '2',
+        'Game Of Kill Everyone',
+        '2014',
+    );
+
+    $publisherA = new Publisher(
+        'Elephant books',
+        'Amazon rainforests, near the river',
+    );
+    $publisherB = new Publisher(
+        'Bloody Fantasy inc.',
+        'Diagon Alley, before the bank, to the left',
+    );
+
+    $bookA->author = $authorA;
+    $bookA->publisher = $publisherA;
+    $bookA->characters = [$charA, $charB];
+    $authorA->characters = [$charA, $charB];
+    $charA->book = $bookA;
+    $charB->book = $bookA;
+    $publisherA->books = [$bookA];
+    $authorA->books = [$bookA];
+
+    $bookB->author = $authorB;
+    $bookB->publisher = $publisherB;
+    $bookB->characters = [$charC, $charD];
+    $authorB->characters = [$charC, $charD];
+    $charC->book = $bookB;
+    $charD->book = $bookB;
+    $publisherB->books = [$bookB];
+    $authorB->books = [$bookB];
+
+    return [$publisherA, $publisherB];
+}

--- a/tests/TestClasses/Author.php
+++ b/tests/TestClasses/Author.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+class Author
+{
+    public string $name;
+    public string $email;
+    /** @var Book[] */
+    public ?array $books = [];
+
+    public function __construct(string $name, string $email)
+    {
+        $this->name = $name;
+        $this->email = $email;
+    }
+
+    public function books(): array
+    {
+        return $this->books;
+    }
+}

--- a/tests/TestClasses/AuthorTransformer.php
+++ b/tests/TestClasses/AuthorTransformer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+use League\Fractal\Resource\Collection;
+use League\Fractal\TransformerAbstract;
+
+class AuthorTransformer extends TransformerAbstract
+{
+    protected array $availableIncludes = [
+        'books',
+    ];
+
+    public function transform(Author $author): array
+    {
+        return [
+            'name' => $author->name,
+            'email' => $author->email,
+        ];
+    }
+
+    public function includeBooks(Author $author): Collection
+    {
+        return $this->collection($author->books(), new BookTransformer());
+    }
+}

--- a/tests/TestClasses/Book.php
+++ b/tests/TestClasses/Book.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+class Book
+{
+    public string $id;
+    public string $title;
+    public string $yr;
+    public ?Publisher $publisher = null;
+    public ?Author $author = null;
+
+    public function __construct(
+        string $id,
+        string $title,
+        string $yr
+    ) {
+        $this->id = $id;
+        $this->title = $title;
+        $this->yr = $yr;
+    }
+
+    public function publisher(): ?Publisher
+    {
+        return $this->publisher;
+    }
+
+    public function author(): ?Author
+    {
+        return $this->author;
+    }
+}

--- a/tests/TestClasses/BookTransformer.php
+++ b/tests/TestClasses/BookTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+use League\Fractal\Resource\Item;
+use League\Fractal\TransformerAbstract;
+
+class BookTransformer extends TransformerAbstract
+{
+    protected array $availableIncludes = [
+        'publisher',
+        'author',
+    ];
+
+    public function transform(Book $book): array
+    {
+        return [
+            'id' => (int)$book->id,
+            'title' => $book->title,
+        ];
+    }
+
+    public function includePublisher(Book $book): Item
+    {
+        return $this->item($book->publisher(), new PublisherTransformer());
+    }
+
+    public function includeAuthor(Book $book): Item
+    {
+        return $this->item($book->author(), new AuthorTransformer());
+    }
+}

--- a/tests/TestClasses/Publisher.php
+++ b/tests/TestClasses/Publisher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+class Publisher
+{
+    public string $name;
+    public string $address;
+    /** @var Book[] */
+    public array $books = [];
+
+    /**
+     * @param string $name
+     * @param string $address
+     */
+    public function __construct(
+        string $name,
+        string $address
+    ) {
+        $this->name = $name;
+        $this->address = $address;
+    }
+
+    public function books(): array
+    {
+        return $this->books;
+    }
+}

--- a/tests/TestClasses/PublisherTransformer.php
+++ b/tests/TestClasses/PublisherTransformer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+use League\Fractal\Resource\Collection;
+use League\Fractal\TransformerAbstract;
+
+class PublisherTransformer extends TransformerAbstract
+{
+    protected array $availableIncludes = [
+        'books',
+    ];
+
+    public function transform(Publisher $publisher): array
+    {
+        return [
+            'name' => $publisher->name,
+            'address' => $publisher->address,
+        ];
+    }
+
+    public function includeBooks(Publisher $publisher): Collection
+    {
+        return $this->collection($publisher->books(), new BookTransformer());
+    }
+}


### PR DESCRIPTION
# Summary
Add the missing tests for nested includes.

# Description
I added some classes and transformers to be able to test the `nested include` easier. Or else I had to duplicated a lot of arrayii/stringy code.  These new additions also helps adding new tests much easier later.