### PR TITLE
Allow accessing the transformer

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -6,6 +6,7 @@ use JsonSerializable;
 use League\Fractal\Manager;
 use League\Fractal\Pagination\CursorInterface;
 use League\Fractal\Pagination\PaginatorInterface;
+use League\Fractal\TransformerAbstract;
 use Spatie\Fractalistic\Exceptions\InvalidTransformation;
 use Spatie\Fractalistic\Exceptions\NoTransformerSpecified;
 use Traversable;
@@ -21,7 +22,7 @@ class Fractal implements JsonSerializable
     /** @var string|\League\Fractal\Serializer\SerializerAbstract */
     protected $serializer;
 
-    /** @var string|callable|\League\Fractal\TransformerAbstract */
+    /** @var string|callable|\League\Fractal\TransformerAbstract|null */
     protected $transformer;
 
     /** @var \League\Fractal\Pagination\PaginatorInterface */
@@ -177,7 +178,7 @@ class Fractal implements JsonSerializable
     /**
      * Set the class or function that will perform the transform.
      *
-     * @param string|callable|\League\Fractal\TransformerAbstract $transformer
+     * @param string|callable|\League\Fractal\TransformerAbstract|null $transformer
      *
      * @return $this
      */
@@ -461,6 +462,16 @@ class Fractal implements JsonSerializable
     public function jsonSerialize(): ?array
     {
         return $this->toArray();
+    }
+
+    /**
+     * Get the transformer.
+     *
+     * @return string|callable|\League\Fractal\TransformerAbstract|null
+     */
+    public function getTransformer()
+    {
+        return $this->transformer;
     }
 
     /**

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -228,3 +228,27 @@ it('can convert into something that is json serializable', function () {
 
     assertEquals($expectedArray, $jsonSerialized);
 });
+
+it('can get the transformer', function ($transformer): void {
+    $fractal = Fractal::create();
+    $fractal->transformWith($transformer);
+
+    $result = $fractal->getTransformer();
+
+    expect($result)->toBe($transformer);
+})->with([
+    'instance' => [
+        new TestTransformer(),
+    ],
+    'fqcn' => [
+        TestTransformer::class,
+    ],
+    'callable' => [
+        function (): array {
+            return [];
+        },
+    ],
+    'null' => [
+        null,
+    ]
+]);


### PR DESCRIPTION
# Summary
Addded a public method to be able to access the transformer.

# Reasoning
## TL;DR
Using my own extended `Fractal` facade, this allows me to call the `ok` method both **with** and **without** setting a transformer.
* `Fractal::create($this->user, UserTransformer::class)->ok();`
* `Fractal::ok();`

Otherwise, I get a `NoTransformerSpecified` exception.

> Yes, I can just create a `200` response using a thousand other ways but I woud like to be consistence and use the `Fractal` facade to generate all of my responses.
 
## Explanation
### Background
I am using your awesome [larave-fractal](https://github.com/spatie/laravel-fractal/tree/main) package which has the [`Spatie\Fractal\Fractal`](https://github.com/spatie/laravel-fractal/blob/main/src/Fractal.php) that extends the [`Spatie\Fractalistic\Fractal`](https://github.com/spatie/fractalistic/blob/main/src/Fractal.php).

#### Glossary
| When I say | I mean |
|------------|--------|
| `LaravelFractal` | [`Spatie\Fractal\Fractal`](https://github.com/spatie/laravel-fractal/blob/main/src/Fractal.php) |
| `FractalisticFractal` | [`Spatie\Fractalistic\Fractal`](https://github.com/spatie/fractalistic/blob/main/src/Fractal.php) |
| `MyFractal` | My class that extends [`Spatie\Fractal\Fractal`](https://github.com/spatie/laravel-fractal/blob/main/src/Fractal.php) |

### Why
`LaravelFractal` class has a convenient `respond` method that helps with genarating responses.  
In my project I have added some other convenient methods to `MyFractal`. For example,
```php
class MyFractal extends LaravelFractal
{
    public function ok(): JsonResponse
    {
        // notice here, I am using the proposed method
        if (is_null($this->getTransformer())) {
            // `empty` is just another convenient method of mine.
            // It returns a transformer that returns an empty array, [], never mind it!
            $this->transformWith(Transformer::empty());
        }
    
        return $this->respond(200); // I am using the `LaravelFractal::respond`
    }
}
```
Using my own facade, this allows me to call the `ok` method both **with** and **without** setting a transformer.
* `MyFractal::create($this->user, UserTransformer::class)->ok();`
* `MyFractal::ok();`

Otherwise, I get a `NoTransformerSpecified` exception.
This happens because `MyFractal::ok` method uses the `LaravelFractal::respond` method underneath. And in turn,
[`LaravelFractal::respond`](https://github.com/spatie/laravel-fractal/blob/e9fee265f8e9988bc32b0a7641770a0b2e64590f/src/Fractal.php#L89) method calls the [`FractalisticFractal::createData`](https://github.com/spatie/fractalistic/blob/fdb6016dc566c96248f4157e48e95bb08ab06437/src/Fractal.php#L382) method and this method throws an exception if it is called without a transfromer. (which is the case with `MyFractal::ok` mthod)
```php
    public function createData()
    {
        if (is_null($this->transformer)) {
            throw new NoTransformerSpecified();
        }
        // ...
    }
```