### PR TITLE
[BREAKING] Fix empty param bag

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -405,7 +405,7 @@ class Fractal implements JsonSerializable
             $this->manager->parseFieldsets($this->fieldsets);
         }
 
-        return $this->manager->createData($this->getResource(), $this->resourceName);
+        return $this->manager->createData($this->getResource());
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,6 +9,7 @@
 use Spatie\Fractalistic\Fractal;
 use Spatie\Fractalistic\Test\TestClasses\Author;
 use Spatie\Fractalistic\Test\TestClasses\Book;
+use Spatie\Fractalistic\Test\TestClasses\Character;
 use Spatie\Fractalistic\Test\TestClasses\Publisher;
 
 uses()
@@ -56,6 +57,11 @@ function getTestPublishers(): array
     $authorA = new Author('Philip K Dick', 'philip@example.org');
     $authorB = new Author('George R. R. Satan', 'george@example.org');
 
+    $charA = new Character('Death');
+    $charB = new Character('Hex');
+    $charC = new Character('Ned Stark');
+    $charD = new Character('Tywin Lannister');
+
     $bookA = new Book(
         '1',
         'Hogfather',
@@ -78,11 +84,19 @@ function getTestPublishers(): array
 
     $bookA->author = $authorA;
     $bookA->publisher = $publisherA;
+    $bookA->characters = [$charA, $charB];
+    $authorA->characters = [$charA, $charB];
+    $charA->book = $bookA;
+    $charB->book = $bookA;
     $publisherA->books = [$bookA];
     $authorA->books = [$bookA];
 
     $bookB->author = $authorB;
     $bookB->publisher = $publisherB;
+    $bookB->characters = [$charC, $charD];
+    $authorB->characters = [$charC, $charD];
+    $charC->book = $bookB;
+    $charD->book = $bookB;
     $publisherB->books = [$bookB];
     $authorB->books = [$bookB];
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -1,13 +1,47 @@
 <?php
 
-use Spatie\Fractalistic\Test\TestClasses\TestTransformer;
-use function PHPUnit\Framework\assertEquals;
+use League\Fractal\ParamBag;
+use Spatie\Fractalistic\Fractal;
+use Spatie\Fractalistic\Test\TestClasses\PublisherTransformer;
 
-it('uses an identifier for the scope', function () {
-    $scope = $this->fractal
-        ->collection($this->testBooks, new TestTransformer(), 'books')
-        ->parseIncludes('characters')
-        ->createData();
+it('can parse include parameters', function ($resourceName, string $include, string $includeWithParams, ParamBag $expected): void {
+    $fractal = Fractal::create(getTestPublishers(), new PublisherTransformer())
+        ->withResourceName($resourceName)
+        ->parseIncludes($includeWithParams);
 
-    assertEquals('books', $scope->getIdentifier());
-});
+    $scope = $fractal->createData();
+
+    $identifier = $scope->getIdentifier($include);
+    $actualParams = $scope->getManager()->getIncludeParams($identifier);
+    expect($actualParams)->toEqual($expected);
+})->with([
+    [
+        'resource name: string' => 'Publisher',
+    ],
+    [
+        'resource name: null' => null,
+    ],
+])->with([
+    [
+        'include' => 'books',
+        'include_with_params' => 'books:test(2|value)',
+        'expected' => new ParamBag([
+            'test' => ['2', 'value'],
+        ]),
+    ],
+    [
+        'include' => 'books',
+        'include_with_params' => 'books:test(another_value|3):another(1|2|3)',
+        'expected' => new ParamBag([
+            'test' => ['another_value', '3'],
+            'another' => ['1', '2', '3'],
+        ]),
+    ],
+    [
+        'include' => 'books.author',
+        'include_with_params' => 'books.author:test(test|value)',
+        'expected' => new ParamBag([
+            'test' => ['test', 'value'],
+        ]),
+    ],
+]);

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -45,3 +45,124 @@ it('can parse include parameters', function ($resourceName, string $include, str
         ]),
     ],
 ]);
+
+it('can access scope in transformer', function (): void {
+    $fractal = Fractal::create(getTestPublishers(), new PublisherTransformer())
+        ->parseIncludes('books.characters,books.author.characters');
+
+    $result = $fractal->toArray();
+
+    expect($result)->toEqual([
+        'data' => [
+            [
+                'name' => 'Elephant books',
+                'address' => 'Amazon rainforests, near the river',
+                'books' =>
+                    [
+                        'data' => [
+                            [
+                                'id' => 1,
+                                'title' => 'Hogfather',
+                                'characters' => [
+                                    'data' => [
+                                        [
+                                            'name' => 'Death',
+                                            'current_scope' => 'characters',
+                                            'parent_scope' => 'books',
+                                            'scope_identifier' => 'books.characters',
+                                            'called_by_book' => 'yes!',
+                                        ],
+                                        [
+                                            'name' => 'Hex',
+                                            'current_scope' => 'characters',
+                                            'parent_scope' => 'books',
+                                            'scope_identifier' => 'books.characters',
+                                            'called_by_book' => 'yes!',
+                                        ],
+                                    ]
+                                ],
+                                'author' => [
+                                    'data' => [
+                                        'name' => 'Philip K Dick',
+                                        'email' => 'philip@example.org',
+                                        'characters' => [
+                                            'data' => [
+                                                [
+                                                    'name' => 'Death',
+                                                    'current_scope' => 'characters',
+                                                    'parent_scope' => 'author',
+                                                    'scope_identifier' => 'books.author.characters',
+                                                    'called_by_author' => 'indeed!',
+                                                ],
+                                                [
+                                                    'name' => 'Hex',
+                                                    'current_scope' => 'characters',
+                                                    'parent_scope' => 'author',
+                                                    'scope_identifier' => 'books.author.characters',
+                                                    'called_by_author' => 'indeed!',
+                                                ],
+                                            ]
+                                        ],
+                                    ]
+                                ],
+                            ],
+                        ],
+                    ],
+            ],
+            [
+                'name' => 'Bloody Fantasy inc.',
+                'address' => 'Diagon Alley, before the bank, to the left',
+                'books' => [
+                    'data' => [
+                        [
+                            'id' => 2,
+                            'title' => 'Game Of Kill Everyone',
+                            'characters' => [
+                                'data' => [
+                                    [
+                                        'name' => 'Ned Stark',
+                                        'current_scope' => 'characters',
+                                        'parent_scope' => 'books',
+                                        'scope_identifier' => 'books.characters',
+                                        'called_by_book' => 'yes!',
+                                    ],
+                                    [
+                                        'name' => 'Tywin Lannister',
+                                        'current_scope' => 'characters',
+                                        'parent_scope' => 'books',
+                                        'scope_identifier' => 'books.characters',
+                                        'called_by_book' => 'yes!',
+                                    ],
+                                ]
+                            ],
+                            'author' => [
+                                'data' => [
+                                    'name' => 'George R. R. Satan',
+                                    'email' => 'george@example.org',
+                                    'characters' => [
+                                        'data' => [
+                                            [
+                                                'name' => 'Ned Stark',
+                                                'current_scope' => 'characters',
+                                                'parent_scope' => 'author',
+                                                'scope_identifier' => 'books.author.characters',
+                                                'called_by_author' => 'indeed!',
+                                            ],
+                                            [
+                                                'name' => 'Tywin Lannister',
+                                                'current_scope' => 'characters',
+                                                'parent_scope' => 'author',
+                                                'scope_identifier' => 'books.author.characters',
+                                                'called_by_author' => 'indeed!',
+                                            ],
+                                        ]
+                                    ],
+                                ],
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+});

--- a/tests/TestClasses/Author.php
+++ b/tests/TestClasses/Author.php
@@ -8,6 +8,8 @@ class Author
     public string $email;
     /** @var Book[] */
     public ?array $books = [];
+    /** @var Character[] */
+    public array $characters = [];
 
     public function __construct(string $name, string $email)
     {
@@ -18,5 +20,10 @@ class Author
     public function books(): array
     {
         return $this->books;
+    }
+
+    public function characters(): array
+    {
+        return $this->characters;
     }
 }

--- a/tests/TestClasses/AuthorTransformer.php
+++ b/tests/TestClasses/AuthorTransformer.php
@@ -9,6 +9,7 @@ class AuthorTransformer extends TransformerAbstract
 {
     protected array $availableIncludes = [
         'books',
+        'characters'
     ];
 
     public function transform(Author $author): array
@@ -22,5 +23,10 @@ class AuthorTransformer extends TransformerAbstract
     public function includeBooks(Author $author): Collection
     {
         return $this->collection($author->books(), new BookTransformer());
+    }
+
+    public function includeCharacters(Author $author): Collection
+    {
+        return $this->collection($author->characters(), new CharacterTransformer());
     }
 }

--- a/tests/TestClasses/Book.php
+++ b/tests/TestClasses/Book.php
@@ -7,6 +7,8 @@ class Book
     public string $id;
     public string $title;
     public string $yr;
+    /** @var Character[] */
+    public array $characters = [];
     public ?Publisher $publisher = null;
     public ?Author $author = null;
 
@@ -23,6 +25,14 @@ class Book
     public function publisher(): ?Publisher
     {
         return $this->publisher;
+    }
+
+    /**
+     * @return Character[]
+     */
+    public function characters(): array
+    {
+        return $this->characters;
     }
 
     public function author(): ?Author

--- a/tests/TestClasses/BookTransformer.php
+++ b/tests/TestClasses/BookTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Fractalistic\Test\TestClasses;
 
+use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use League\Fractal\TransformerAbstract;
 
@@ -9,6 +10,7 @@ class BookTransformer extends TransformerAbstract
 {
     protected array $availableIncludes = [
         'publisher',
+        'characters',
         'author',
     ];
 
@@ -23,6 +25,11 @@ class BookTransformer extends TransformerAbstract
     public function includePublisher(Book $book): Item
     {
         return $this->item($book->publisher(), new PublisherTransformer());
+    }
+
+    public function includeCharacters(Book $book): Collection
+    {
+        return $this->collection($book->characters(), new CharacterTransformer());
     }
 
     public function includeAuthor(Book $book): Item

--- a/tests/TestClasses/Character.php
+++ b/tests/TestClasses/Character.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+class Character
+{
+    public string $name;
+    public ?Book $book = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function book(): ?Book
+    {
+        return $this->book;
+    }
+}

--- a/tests/TestClasses/CharacterTransformer.php
+++ b/tests/TestClasses/CharacterTransformer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spatie\Fractalistic\Test\TestClasses;
+
+use League\Fractal\Resource\Item;
+use League\Fractal\TransformerAbstract;
+
+final class CharacterTransformer extends TransformerAbstract
+{
+    protected array $availableIncludes = [
+        'book',
+        'author',
+    ];
+
+    public function transform(Character $character): array
+    {
+        $parentScope = last($this->getCurrentScope()->getParentScopes());
+        $data = [
+            'name' => $character->name,
+            'current_scope' => $this->getCurrentScope()->getScopeIdentifier(),
+            'parent_scope' => $parentScope,
+            'scope_identifier' => $this->getCurrentScope()->getIdentifier(),
+        ];
+
+        if ($parentScope === 'author') {
+            $data['called_by_author'] = 'indeed!';
+        }
+
+        if ($parentScope === 'books') {
+            $data['called_by_book'] = 'yes!';
+        }
+
+        return $data;
+    }
+
+    public function includeBook(Character $character): Item
+    {
+        return $this->item($character->book(), new BookTransformer());
+    }
+}


### PR DESCRIPTION
# Notes
* This PR introduces a **BREAKING CHANGE**.
* ~~This PR is based on #79 and utilizes the test classes introduced there. To make the review process smoother, it’s recommended that this PR be merged after #79.~~

# Summary

This PR addresses #49 and #62, both of which were caused by the changes introduced in #39.

The issue occurs when using the withResourceName method or setting the resource name in any other way, causing the include parameters to be empty. This problem is clearly described in #62.

# More Context

In the use case described in #38, if the data returned by Country differs depending on the context (e.g., in the Portfolio context vs. other contexts), it indicates that a different or new transformer should be used for each context. This is precisely what transformers and includes are designed for: to return different data based on context.

If you need to return different data based on context, it is still possible to do so, as demonstrated in the test case.

resolve #49
resolve #62 