### PR TITLE
Update docblock

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -46,8 +46,8 @@ class Fractal implements JsonSerializable
     /** @var mixed */
     protected $data;
 
-    /** @var string */
-    protected $resourceName;
+    /** @var string|null */
+    protected $resourceName = null;
 
     /** @var array */
     protected $meta = [];

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -446,7 +446,7 @@ class Fractal implements JsonSerializable
     /**
      * Return the name of the resource.
      *
-     * @return string
+     * @return string|null
      */
     public function getResourceName()
     {


### PR DESCRIPTION
Since `$resourceName` can possibly be uninitialized, I added the proper dockblock and also initialized it with `null`.
I also updated the docblock of `getResourceName` method which returns it to match its new possible values.