### PR TITLE
Allow overriding resource classes

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -410,6 +410,24 @@ class Fractal implements JsonSerializable
     }
 
     /**
+     * Get the resource class.
+     *
+     * @return string
+     *
+     * @throws \Spatie\Fractalistic\Exceptions\InvalidTransformation
+     */
+    public function getResourceClass(): string
+    {
+        $class = 'League\\Fractal\\Resource\\'.ucfirst($this->dataType);
+
+        if (! class_exists($class)) {
+            throw new InvalidTransformation();
+        }
+
+        return $class;
+    }
+
+    /**
      * Get the resource.
      *
      * @return \League\Fractal\Resource\ResourceInterface
@@ -418,16 +436,11 @@ class Fractal implements JsonSerializable
      */
     public function getResource()
     {
-        $resourceClass = 'League\\Fractal\\Resource\\'.ucfirst($this->dataType);
-
-        if (! class_exists($resourceClass)) {
-            throw new InvalidTransformation();
-        }
-
         if (is_string($this->transformer)) {
             $this->transformer = new $this->transformer;
         }
 
+        $resourceClass = $this->getResourceClass();
         $resource = new $resourceClass($this->data, $this->transformer, $this->resourceName);
 
         $resource->setMeta($this->meta);

--- a/tests/FractalTest.php
+++ b/tests/FractalTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use League\Fractal\Pagination\Cursor;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Resource\ResourceInterface;
 use League\Fractal\Serializer\JsonApiSerializer;
 use Spatie\Fractalistic\ArraySerializer;
@@ -252,3 +255,20 @@ it('can get the transformer', function ($transformer): void {
         null,
     ]
 ]);
+
+it('can locate default resource classes', function (): void {
+    $resource = Fractal::create()->item([])->transformWith(new TestTransformer());
+    expect($resource->getResourceClass())->toBe(Item::class);
+
+    $resource = Fractal::create('test', new TestTransformer());
+    expect($resource->getResourceClass())->toBe(Item::class);
+
+    $resource = Fractal::create()->collection([])->transformWith(new TestTransformer());
+    expect($resource->getResourceClass())->toBe(Collection::class);
+
+    $resource = Fractal::create([], new TestTransformer());
+    expect($resource->getResourceClass())->toBe(Collection::class);
+
+    $resource = Fractal::create(null, new TestTransformer());
+    expect($resource->getResourceClass())->toBe(NullResource::class);
+});


### PR DESCRIPTION
I just extracted the class discovery logic into a method to allow customizing it's logic.
There is no breaking change in this PR as it is a simple refactoring.

Here is an example of how I leveraged this changes to to use my own `Resource` classes:
```php
public function getResourceClass(): string
{
    if ('item' === $this->dataType) {
        return My\Custum\Resources\Item::class;
    }

    if ('collection' === $this->dataType) {
        return My\Custum\Resources\Collection::class;
    }

    return parent::getResourceClass();
}
```